### PR TITLE
Fix unaligned history #3

### DIFF
--- a/src/puzzle.mst
+++ b/src/puzzle.mst
@@ -58,11 +58,11 @@
             </div>
 
             <!-- Guess History -->
-            <ul class="flex-column-center" x-data>
+            <div class="flex-column-center" x-data>
                 <template x-for="guess in $store.guesshistory">
-                    <li x-text="guess.niceName" class="alert width-100p" :class="guess.correct ? 'style-success' : 'style-danger'"></li>
+                    <p x-text="guess.niceName" class="alert width-100p" :class="guess.correct ? 'style-success' : 'style-danger'"></p>
                 </template>
-            </ul>
+            </div>
 
             <!-- Footer -->
             <hr/>


### PR DESCRIPTION
![image](https://github.com/benolot/voiceline-guessing-game/assets/143093214/c339e4cc-75a2-4de1-8b30-cf074a9de0ff)

The reason for this bug is the root-padding for ul and li in flatify which is set to 2em. To fix this, I changed it to div and p, but I could also overwrite the root-padding or make a specific !important style for this instead, so if this way doesn't suit then I can change it, but I hope this helps!