### PR TITLE
Add option to perform "clean" build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "node render.js"
+    "build": "node render.js",
+    "cleanbuild": "node render.js clean"
   },
   "repository": {
     "type": "git",

--- a/render.js
+++ b/render.js
@@ -5,7 +5,7 @@ const Mustache = require('mustache');
 const puzzles = JSON.parse(fs.readFileSync('src/puzzles.json', 'utf-8'));
 
 // Get the args after `node render.js`
-var args = process.argv.slice(2);
+const args = process.argv.slice(2);
 if (args[0] == 'clean') {
     console.log('Clean build requested, removing dist folder if it exists')
     if (fs.existsSync('dist')) {

--- a/render.js
+++ b/render.js
@@ -4,12 +4,18 @@ const fs = require('fs');
 const Mustache = require('mustache');
 const puzzles = JSON.parse(fs.readFileSync('src/puzzles.json', 'utf-8'));
 
-console.log('Creating dist folders if they dont already exist...');
-if (!fs.existsSync('dist')) {
-    fs.mkdirSync('dist');
+// Get the args after `node render.js`
+var args = process.argv.slice(2);
+if (args[0] == 'clean') {
+    console.log('Clean build requested, removing dist folder if it exists')
+    if (fs.existsSync('dist')) {
+        fs.rmSync('dist', { recursive: true });
+    }
 }
+
+console.log('Creating dist folders if they dont already exist...');
 if (!fs.existsSync('dist/res')) {
-    fs.mkdirSync('dist/res');
+    fs.mkdirSync('dist/res', { recursive: true });
 }
 
 function renderPuzzle(data) {


### PR DESCRIPTION
Adds an argument to `render.js` delete the current `dist` directory if it exists

Currently the `dist` directory is persistent between executions of `npm build`, which results in content not being removed from `dist` when it has been removed from the source directories. This potentially results in unwanted files remaining after they should have been removed.